### PR TITLE
Update to Python3 style of print

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Python 2 and 3 both work for this. Use [pip](https://pip.pypa.io/en/stable/) to 
 
 ##Usage
 
-Just run ``demo.py`` to see the results.
+Just run ``python3 demo.py`` to see the results:
+
+   ```
+Starting gradient descent at b = 0, m = 0, error = 5565.107834483211
+Running...
+After 1000 iterations b = 0.08893651993741346, m = 1.4777440851894448, error = 112.61481011613473
+   ```
 
 ##Credits
 

--- a/demo.py
+++ b/demo.py
@@ -35,10 +35,10 @@ def run():
     initial_b = 0 # initial y-intercept guess
     initial_m = 0 # initial slope guess
     num_iterations = 1000
-    print "Starting gradient descent at b = {0}, m = {1}, error = {2}".format(initial_b, initial_m, compute_error_for_line_given_points(initial_b, initial_m, points))
-    print "Running..."
+    print("Starting gradient descent at b = {0}, m = {1}, error = {2}".format(initial_b, initial_m, compute_error_for_line_given_points(initial_b, initial_m, points)))
+    print("Running...")
     [b, m] = gradient_descent_runner(points, initial_b, initial_m, learning_rate, num_iterations)
-    print "After {0} iterations b = {1}, m = {2}, error = {3}".format(num_iterations, b, m, compute_error_for_line_given_points(b, m, points))
+    print("After {0} iterations b = {1}, m = {2}, error = {3}".format(num_iterations, b, m, compute_error_for_line_given_points(b, m, points)))
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
The Udacity course materials says Python3 is preferred.

But when I run using ``python3 demo.py` there is an error.
http://stackoverflow.com/questions/826948/syntax-error-on-print-with-python-3

So I made the change to put what is printed between quotes.

I also added the Python command in the README.md file.